### PR TITLE
Replace reqwest with a combination of `curl` and `pbr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ edition = "2018"
 
 [features]
 default = []
-download = ["reqwest", "flate2"]
+download = ["curl", "pbr", "flate2"]
 
 [dependencies]
 byteorder = "1.0.0"
 
 # Used to download datasets
-reqwest = {version = "0.10", optional = true, features = ["blocking"]}
+curl = {version = "0.4", optional = true}
+pbr = {version = "1.0", optional = true}
 flate2 = {version = "1.0.2", optional = true, features = ["rust_backend"], default-features = false}
 
 [dev-dependencies]

--- a/examples/mnist.rs
+++ b/examples/mnist.rs
@@ -1,0 +1,85 @@
+extern crate mnist;
+use image::*;
+use mnist::*;
+use ndarray::prelude::*;
+use show_image::{make_window_full, Event, WindowOptions};
+
+fn main() {
+    let (trn_size, _rows, _cols) = (50_000, 28, 28);
+
+    // Deconstruct the returned Mnist struct.
+    let Mnist {
+        trn_img, trn_lbl, ..
+    } = MnistBuilder::new()
+        // .use_fashion_data() // Comment out this and the changed `.base_path()` to run on the original MNIST
+        //.base_url("<some_other_url>") // Since the base url is sometimes down due to high demand, you can replace is with another
+        .base_path("data/") // Comment out this and `use_fashion_data()` to run on the original MNIST
+        .label_format_digit()
+        .training_set_length(trn_size)
+        .validation_set_length(10_000)
+        .test_set_length(10_000)
+        .download_and_extract()
+        .finalize();
+
+    let item_num = 3;
+    return_item_description_from_number(trn_lbl[item_num]);
+
+    let train_data = Array3::from_shape_vec((50_000, 28, 28), trn_img)
+        .expect("Error converting images to Array3 struct")
+        .mapv(|x| x as f32 / 256.);
+
+    let image = bw_ndarray2_to_rgb_image(train_data.slice(s![item_num, .., ..]).to_owned());
+    let window_options = WindowOptions {
+        name: "image".to_string(),
+        size: [100, 100],
+        resizable: true,
+        preserve_aspect_ratio: true,
+    };
+    let window = make_window_full(window_options).unwrap();
+    window.set_image(image, "test_result").unwrap();
+
+    for event in window.events() {
+        if let Event::KeyboardEvent(event) = event {
+            if event.key == show_image::KeyCode::Escape {
+                break;
+            }
+        }
+    }
+
+    show_image::stop().unwrap();
+}
+
+fn return_item_description_from_number(val: u8) {
+    let description = match val {
+        0 => "0",
+        1 => "1",
+        2 => "2",
+        3 => "3",
+        4 => "4",
+        5 => "5",
+        6 => "6",
+        7 => "7",
+        8 => "8",
+        9 => "9",
+        _ => panic!("An unrecognized label was used..."),
+    };
+    println!(
+        "Based on the '{}' label, this image should be a: {} ",
+        val, description
+    );
+    println!("Hit [ ESC ] to exit...");
+}
+
+fn bw_ndarray2_to_rgb_image(arr: Array2<f32>) -> RgbImage {
+    assert!(arr.is_standard_layout());
+
+    let (width, height) = (arr.ncols(), arr.ncols());
+    let mut img: RgbImage = ImageBuffer::new(width as u32, height as u32);
+    for y in 0..height {
+        for x in 0..width {
+            let val = (arr[[y, x]] * 255.) as u8;
+            img.put_pixel(x as u32, y as u32, image::Rgb([val, val, val]))
+        }
+    }
+    img
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,26 +1,39 @@
 #![cfg(feature = "download")]
 
-extern crate flate2;
-extern crate reqwest;
-
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-const BASE_URL: &str = "http://yann.lecun.com/exdb/mnist";
-const FASHION_BASE_URL: &str = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com";
+use curl::easy::Easy;
+use std::fs::File;
+// use std::io::{stdout, Write};
+
+use pbr::ProgressBar;
+use std::convert::TryInto;
+use std::thread;
+
 const ARCHIVE_TRAIN_IMAGES: &str = "train-images-idx3-ubyte.gz";
+const ARCHIVE_TRAIN_IMAGES_SIZE: usize = 9912422;
 const ARCHIVE_TRAIN_LABELS: &str = "train-labels-idx1-ubyte.gz";
+const ARCHIVE_TRAIN_LABELS_SIZE: usize = 28881;
 const ARCHIVE_TEST_IMAGES: &str = "t10k-images-idx3-ubyte.gz";
+const ARCHIVE_TEST_IMAGES_SIZE: usize = 1648877;
 const ARCHIVE_TEST_LABELS: &str = "t10k-labels-idx1-ubyte.gz";
+const ARCHIVE_TEST_LABELS_SIZE: usize = 4542;
 const ARCHIVES_TO_DOWNLOAD: &[&str] = &[
     ARCHIVE_TRAIN_IMAGES,
     ARCHIVE_TRAIN_LABELS,
     ARCHIVE_TEST_IMAGES,
     ARCHIVE_TEST_LABELS,
 ];
+const ARCHIVE_DOWNLOAD_SIZES: &[usize] = &[
+    ARCHIVE_TRAIN_IMAGES_SIZE,
+    ARCHIVE_TRAIN_LABELS_SIZE,
+    ARCHIVE_TEST_IMAGES_SIZE,
+    ARCHIVE_TEST_LABELS_SIZE,
+];
 
-pub(super) fn download_and_extract(base_path: &str, use_fashion_data: bool) -> Result<(), String> {
+pub(super) fn download_and_extract(base_url: &str, base_path: &str, use_fashion_data: bool) -> Result<(), String> {
     let download_dir = PathBuf::from(base_path);
     if !download_dir.exists() {
         println!(
@@ -36,40 +49,70 @@ pub(super) fn download_and_extract(base_path: &str, use_fashion_data: bool) -> R
     }
     for archive in ARCHIVES_TO_DOWNLOAD {
         println!("Attempting to download and extract {}...", archive);
-        download(&archive, &download_dir, use_fashion_data)?;
+        download(base_url, &archive, &download_dir, use_fashion_data)?;
         extract(&archive, &download_dir)?;
     }
     Ok(())
 }
 
-fn download(archive: &str, download_dir: &Path, use_fashion_data: bool) -> Result<(), String> {
-    let url = match use_fashion_data {
-        false => format!("{}/{}", BASE_URL, archive),
-        true => format!("{}/{}", FASHION_BASE_URL, archive),
-    };
-
-    let file_name = download_dir.join(&archive);
-    if file_name.exists() {
-        println!(
-            "  File {:?} already exists, skipping downloading.",
-            file_name
-        );
-    } else {
-        println!("  Downloading {} to {:?}...", url, download_dir);
-        let f = fs::File::create(&file_name)
-            .or_else(|e| Err(format!("Failed to create file {:?}: {:?}", file_name, e)))?;
-        let mut writer = io::BufWriter::new(f);
-        let mut response =
-            reqwest::blocking::get(&url).expect(format!("Failed to download {:?}", url).as_str());
-
-        let _ = io::copy(&mut response, &mut writer).or_else(|e| {
-            Err(format!(
-                "Failed to to write to file {:?}: {:?}",
-                file_name, e
-            ))
-        })?;
-        println!("  Downloading or {} to {:?} done!", archive, download_dir);
+fn download(base_url: &str, archive: &str, download_dir: &Path, use_fashion_data: bool) -> Result<(), String> {
+    
+    let mut easy = Easy::new();
+    for i in 0..4 {
+        let archive = ARCHIVES_TO_DOWNLOAD[i];
+        let url = Path::new(base_url).join(archive);
+        let file_name = download_dir.to_str().unwrap().to_owned() + archive; //.clone();
+        if Path::new(&file_name).exists() {
+            println!(
+                "  File {:?} already exists, skipping downloading.",
+                file_name
+            );
+        }
+        else {
+            println!(
+                "- Downloading from file from {} and saving to file as: {}",
+                url.to_str().unwrap(), file_name
+            );
+    
+            let mut file = File::create(file_name.clone()).unwrap();
+    
+            
+            let pb = match cfg!(unix) {
+                true => {
+                    use std::os::unix::fs::MetadataExt;
+                    let full_size = ARCHIVE_DOWNLOAD_SIZES[i];
+    
+                    let pb_thread = thread::spawn(move || {
+                        let mut pb = ProgressBar::new(full_size.try_into().unwrap());
+                        pb.format("╢=> ╟");
+    
+                        let mut current_size = 0;
+                        while current_size < full_size {
+                            let meta = fs::metadata(file_name.clone())
+                                .expect(&format!("Couldn't get metadata on {:?}", file_name));
+                            current_size = meta.size() as usize;
+                            pb.set(current_size.try_into().unwrap());
+                            thread::sleep_ms(10);
+                        }
+                        pb.finish_println(" ");
+                        
+                    });
+    
+                    easy.url(&url.to_str().unwrap()).unwrap();
+                    easy.write_function(move |data| {
+                        file.write_all(data).unwrap();
+                        Ok(data.len())
+                    })
+                    .unwrap();
+                    easy.perform().unwrap();
+                    pb_thread.join().unwrap();
+                }
+                _ => (),
+            };
+        }
+        
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
As mentioned by Lorenz, the `reqwest` crate is fairly heavy in its dependency requirements. To get the same functionality, I've replaced with a combination of `curl` and `pbr` (an ascii progress bar crate) for visualizing download progress. 

In addition, since the standard `BASE_URL` at http://yann.lecun.com/exdb/mnist/ has often ended up being down, I've added a new function to the Builder struct that allows passing a custom base url. I've tested this on cmoran.xyz (with the associated `.gz` filenames on the end), which seems to work fine. 